### PR TITLE
Flett indexing

### DIFF
--- a/src/devices/nvme.hpp
+++ b/src/devices/nvme.hpp
@@ -56,27 +56,3 @@ class BasicNVMeDrive : public NVMeDrive
     std::vector<uint8_t> manufacturer;
     std::vector<uint8_t> serial;
 };
-
-template <DerivesDevice T>
-class PolledBasicNVMeDrivePresence : public PolledDevicePresence<T>
-{
-  public:
-    PolledBasicNVMeDrivePresence() : bus("/")
-    {}
-    PolledBasicNVMeDrivePresence(SysfsI2CBus bus, Connector<T>* connector) :
-        PolledDevicePresence<T>(connector), bus(bus)
-    {}
-    ~PolledBasicNVMeDrivePresence() = default;
-
-    PolledBasicNVMeDrivePresence<T>&
-        operator=(const PolledBasicNVMeDrivePresence<T>& other) = default;
-
-    /* PolledDevicePresence */
-    virtual bool poll() override
-    {
-        return BasicNVMeDrive::isBasicEndpointPresent(bus);
-    }
-
-  private:
-    SysfsI2CBus bus;
-};

--- a/src/notify.cpp
+++ b/src/notify.cpp
@@ -104,12 +104,19 @@ void Notifier::add(NotifySink* sink)
 
 void Notifier::remove(NotifySink* sink)
 {
-    int rc = ::epoll_ctl(epollfd, EPOLL_CTL_DEL, sink->getFD(), NULL);
+    int fd = sink->getFD();
+    if (fd == -1)
+    {
+        debug("Skipping disarmed sink");
+        return;
+    }
+
+    int rc = ::epoll_ctl(epollfd, EPOLL_CTL_DEL, fd, NULL);
     if (rc < 0)
     {
         error(
             "epoll delete operation failed on epoll descriptor {EPOLL_FD} for event descriptor {EVENT_FD}: {ERRNO_DESCRIPTION}",
-            "EPOLL_FD", epollfd, "EVENT_FD", sink->getFD(), "ERRNO_DESCRIPTION",
+            "EPOLL_FD", epollfd, "EVENT_FD", fd, "ERRNO_DESCRIPTION",
             ::strerror(errno), "ERRNO", errno);
         throw std::system_category().default_error_condition(errno);
     }

--- a/src/notify.cpp
+++ b/src/notify.cpp
@@ -114,10 +114,10 @@ void Notifier::remove(NotifySink* sink)
         throw std::system_category().default_error_condition(errno);
     }
 
-    sink->disarm();
-
     debug("Removed event descriptor {EVENT_FD} from epoll ({EPOLL_FD})",
           "EVENT_FD", sink->getFD(), "EPOLL_FD", epollfd);
+
+    sink->disarm();
 }
 
 void Notifier::run()

--- a/src/notify.cpp
+++ b/src/notify.cpp
@@ -169,8 +169,9 @@ void Notifier::run()
         }
         catch (const SysfsI2CDeviceDriverBindException& ex)
         {
-            error("Failed to bind device from Notifier: {EXCEPTION}",
+            error("Failed to bind device from Notifier, disabling: {EXCEPTION}",
                   "EXCEPTION", ex);
+            remove(sink);
         }
     }
 

--- a/src/notify.cpp
+++ b/src/notify.cpp
@@ -2,8 +2,6 @@
 
 #include "notify.hpp"
 
-#include "sysfs/i2c.hpp"
-
 #include <unistd.h>
 
 #include <phosphor-logging/lg2.hpp>
@@ -163,16 +161,7 @@ void Notifier::run()
         }
 
         /* If it's not the exitfd sentinel it's a regular NotifySink */
-        try
-        {
-            sink->notify(*this);
-        }
-        catch (const SysfsI2CDeviceDriverBindException& ex)
-        {
-            error("Failed to bind device from Notifier, disabling: {EXCEPTION}",
-                  "EXCEPTION", ex);
-            remove(sink);
-        }
+        sink->notify(*this);
     }
 
     if (rc < 0)

--- a/src/notify.hpp
+++ b/src/notify.hpp
@@ -19,6 +19,7 @@ class Notifier
 
   private:
     int epollfd;
+    int exitfd;
 };
 
 class NotifySink

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -174,6 +174,7 @@ class PolledDevicePresence : public NotifySink
     {
         assert(timer > -1 && "Bad state: Timer already disarmed");
         ::close(timerfd);
+        timerfd = -1;
     }
 
   private:

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -100,15 +100,13 @@ class PolledDevicePresence : public NotifySink
 {
   public:
     PolledDevicePresence() = default;
-    PolledDevicePresence(Connector<T>* connector) :
-        connector(connector), timerfd(-1)
+    PolledDevicePresence(Connector<T>* connector, std::function<bool()> poll) :
+        connector(connector), poll(poll), timerfd(-1)
     {}
     virtual ~PolledDevicePresence() = default;
 
     PolledDevicePresence<T>&
         operator=(const PolledDevicePresence<T>& other) = default;
-
-    virtual bool poll() = 0;
 
     /* NotifySink */
     virtual void arm() override
@@ -207,30 +205,8 @@ class PolledDevicePresence : public NotifySink
     }
 
     Connector<T>* connector;
+    std::function<bool()> poll;
     int timerfd;
-};
-
-template <DerivesDevice T>
-class PolledGPIODevicePresence : public PolledDevicePresence<T>
-{
-  public:
-    PolledGPIODevicePresence() = default;
-    PolledGPIODevicePresence(gpiod::line* line, Connector<T>* connector) :
-        PolledDevicePresence<T>(connector), line(line)
-    {}
-    ~PolledGPIODevicePresence() = default;
-
-    PolledGPIODevicePresence<T>&
-        operator=(const PolledGPIODevicePresence<T>& other) = default;
-
-    /* PolledDevicePresence */
-    virtual bool poll() override
-    {
-        return line->get_value();
-    }
-
-  private:
-    gpiod::line* line;
 };
 
 class Platform;

--- a/src/platforms/rainier.hpp
+++ b/src/platforms/rainier.hpp
@@ -80,8 +80,7 @@ class Flett : public Device
     const Nisqually* nisqually;
     int slot;
     std::array<Connector<FlettNVMeDrive>, 8> driveConnectors;
-    std::array<PolledBasicNVMeDrivePresence<FlettNVMeDrive>, 8>
-        presenceAdaptors;
+    std::array<PolledDevicePresence<FlettNVMeDrive>, 8> presenceAdaptors;
 };
 
 class WilliwakasNVMeDrive : public NVMeDrive
@@ -158,8 +157,7 @@ class Williwakas : public Device, FRU
      * effectively */
     std::array<gpiod::line, 8> lines;
     std::array<Connector<WilliwakasNVMeDrive>, 8> driveConnectors;
-    std::array<PolledGPIODevicePresence<WilliwakasNVMeDrive>, 8>
-        presenceAdaptors;
+    std::array<PolledDevicePresence<WilliwakasNVMeDrive>, 8> presenceAdaptors;
 
     bool isDrivePresent(int index);
     void detectDrives(Notifier& notifier);

--- a/src/platforms/rainier/flett.cpp
+++ b/src/platforms/rainier/flett.cpp
@@ -21,21 +21,7 @@ FlettNVMeDrive::FlettNVMeDrive(Inventory* inventory, const Nisqually* nisqually,
                                const Flett* flett, int index) :
     BasicNVMeDrive(flett->getDriveBus(index), inventory, index),
     nisqually(nisqually), flett(flett)
-{
-    try
-    {
-        SysfsI2CBus bus = flett->getDriveBus(index);
-        SysfsI2CDevice eeprom =
-            bus.probeDevice("24c02", NVMeDrive::eepromAddress);
-        lg2::info("EEPROM device exists at '{EEPROM_PATH}'", "EEPROM_PATH",
-                  eeprom.getPath().string());
-    }
-    catch (const SysfsI2CDeviceDriverBindException& ex)
-    {
-        NVMeDrive::~NVMeDrive();
-        throw ex;
-    }
-}
+{}
 
 void FlettNVMeDrive::plug([[maybe_unused]] Notifier& notifier)
 {

--- a/src/platforms/rainier/flett.cpp
+++ b/src/platforms/rainier/flett.cpp
@@ -209,8 +209,10 @@ void Flett::plug(Notifier& notifier)
 {
     for (std::size_t i = 0; i < presenceAdaptors.size(); i++)
     {
-        presenceAdaptors[i] = PolledBasicNVMeDrivePresence<FlettNVMeDrive>(
-            getDriveBus(flett_channel_drive_map.at(i)), &driveConnectors.at(i));
+        SysfsI2CBus bus = getDriveBus(flett_channel_drive_map.at(i));
+        presenceAdaptors[i] = PolledDevicePresence<FlettNVMeDrive>(
+            &driveConnectors.at(i),
+            [bus]() { return BasicNVMeDrive::isBasicEndpointPresent(bus); });
         notifier.add(&presenceAdaptors.at(i));
     }
 }

--- a/src/platforms/rainier/nisqually.cpp
+++ b/src/platforms/rainier/nisqually.cpp
@@ -32,11 +32,17 @@ static const std::map<int, int> flett_slot_presence_map = {
     {11, 11},
 };
 
-static const std::map<int, int> flett_index_map = {
+/* See Rainier_System_Workbook_v1.7.pdf, 4.4.4 NVMe JBOF to Backplane Cabling
+ *
+ * The workbook dictates that only two Williwakas/Flett pairs are present, but
+ * the schematics haven't elided the support for the presence of three pairs. We
+ * follow the schematics as an engineering reference point.
+ */
+static const std::map<int, int> flett_slot_index_map = {
     {8, 0},
-    {9, 1},
+    {9, 2},
     {10, 0},
-    {11, 2},
+    {11, 1},
 };
 
 static const std::map<int, int> flett_connector_slot_map = {
@@ -50,7 +56,7 @@ static const std::map<int, int> flett_connector_slot_map = {
 
 int Nisqually::getFlettIndex(int slot)
 {
-    return flett_index_map.at(slot);
+    return flett_slot_index_map.at(slot);
 }
 
 Nisqually::Nisqually(Inventory* inventory) :

--- a/src/platforms/rainier/williwakas.cpp
+++ b/src/platforms/rainier/williwakas.cpp
@@ -139,8 +139,6 @@ void Williwakas::plug(Notifier& notifier)
             &line, &driveConnectors.at(i));
         notifier.add(&presenceAdaptors.at(i));
     }
-
-    detectDrives(notifier);
 }
 
 void Williwakas::unplug(Notifier& notifier, int mode)
@@ -156,30 +154,6 @@ void Williwakas::unplug(Notifier& notifier, int mode)
         {
             connector.getDevice().unplug(notifier, mode);
             connector.depopulate();
-        }
-    }
-}
-
-void Williwakas::detectDrives(Notifier& notifier)
-{
-    debug("Locating NVMe drives from drive backplane {WILLIWAKAS_ID}",
-          "WILLIWAKAS_ID", index);
-
-    assert(driveConnectors.size() == lines.size());
-    for (std::size_t i = 0; i < driveConnectors.size(); i++)
-    {
-        /* FIXME: work around libgpiod bug */
-        if (lines[i].get_value())
-        {
-            driveConnectors[i].populate();
-            driveConnectors[i].getDevice().plug(notifier);
-            info("Found drive {NVME_ID} on backplane {WILLIWAKAS_ID}",
-                 "NVME_ID", i, "WILLIWAKAS_ID", index);
-        }
-        else
-        {
-            debug("Drive {NVME_ID} not present on backplane {WILLIWAKAS_ID}",
-                  "NVME_ID", i, "WILLIWAKAS_ID", index);
         }
     }
 }

--- a/src/platforms/rainier/williwakas.cpp
+++ b/src/platforms/rainier/williwakas.cpp
@@ -134,9 +134,9 @@ void Williwakas::plug(Notifier& notifier)
     assert(driveConnectors.size() == lines.size());
     for (std::size_t i = 0; i < driveConnectors.size(); i++)
     {
-        gpiod::line& line = lines[i];
-        presenceAdaptors[i] = PolledGPIODevicePresence<WilliwakasNVMeDrive>(
-            &line, &driveConnectors.at(i));
+        gpiod::line* line = &lines[i];
+        presenceAdaptors[i] = PolledDevicePresence<WilliwakasNVMeDrive>(
+            &driveConnectors.at(i), [line]() { return line->get_value(); });
         notifier.add(&presenceAdaptors.at(i));
     }
 }

--- a/src/sysfs/i2c/bus.cpp
+++ b/src/sysfs/i2c/bus.cpp
@@ -176,8 +176,9 @@ SysfsI2CDevice SysfsI2CBus::probeDevice(std::string type, int address)
 
     if (!std::filesystem::exists(driver))
     {
-        error("No driver bound for '{SYSFS_I2C_DEVICE_PATH}'",
+        error("No driver bound for '{SYSFS_I2C_DEVICE_PATH}', removing device",
               "SYSFS_I2C_DEVICE_PATH", device.getPath());
+        deleteDevice(address);
         throw SysfsI2CDeviceDriverBindException(device);
     }
 


### PR DESCRIPTION
This builds on #6, fixing up the Flett slot / index relationships so all drives plugging into e.g. rain510 appear and are monitored.

In the process some exception handling is tidied up and probing of the drive EEPROMs is removed as it causes failures to monitor some drives. We don't use the drive EEPROM data right now anyway, and for the most part they appear as erased on systems in the lab.