### PR TITLE
Add support for enabling PCIe card TMP435 drivers when PCIe slot power turns on

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -18,13 +18,13 @@ void EnvironmentManager::enrollEnvironment(ExecutionEnvironment* env)
     environments.push_back(env);
 }
 
-void EnvironmentManager::run(PlatformManager& pm, Inventory* inventory)
+void EnvironmentManager::run(PlatformManager& pm)
 {
     for (auto& env : environments)
     {
         if (env->probe())
         {
-            return env->run(pm, inventory);
+            return env->run(pm);
         }
     }
 }
@@ -92,13 +92,13 @@ bool SimicsExecutionEnvironment::probe()
     return SimicsExecutionEnvironment::isSimicsExecutionEnvironment();
 }
 
-void SimicsExecutionEnvironment::run(PlatformManager& pm, Inventory* inventory)
+void SimicsExecutionEnvironment::run(PlatformManager& pm)
 {
     /* Work around any issues in simics modelling to unblock CI */
     warning("Executing in a simics environment, catching all exceptions");
     try
     {
-        pm.detectPlatformFrus(inventory);
+        pm.detectPlatformFrus();
     }
     catch (const std::exception& ex)
     {
@@ -118,9 +118,8 @@ bool HardwareExecutionEnvironment::probe()
     return !SimicsExecutionEnvironment::isSimicsExecutionEnvironment();
 }
 
-void HardwareExecutionEnvironment::run(PlatformManager& pm,
-                                       Inventory* inventory)
+void HardwareExecutionEnvironment::run(PlatformManager& pm)
 {
     debug("Executing in a hardware environment, propagating all exceptions");
-    pm.detectPlatformFrus(inventory);
+    pm.detectPlatformFrus();
 }

--- a/src/environment.hpp
+++ b/src/environment.hpp
@@ -14,7 +14,7 @@ class EnvironmentManager
     ~EnvironmentManager() = default;
 
     void enrollEnvironment(ExecutionEnvironment* env);
-    void run(PlatformManager& pm, Inventory* inventory);
+    void run(PlatformManager& pm);
 
   private:
     std::list<ExecutionEnvironment*> environments;
@@ -27,7 +27,7 @@ class ExecutionEnvironment
     virtual ~ExecutionEnvironment() = default;
 
     virtual bool probe() = 0;
-    virtual void run(PlatformManager& pm, Inventory* inventory) = 0;
+    virtual void run(PlatformManager& pm) = 0;
 };
 
 class SimicsExecutionEnvironment : public ExecutionEnvironment
@@ -40,7 +40,7 @@ class SimicsExecutionEnvironment : public ExecutionEnvironment
 
     /* ExecutionEnvironment */
     virtual bool probe() override;
-    virtual void run(PlatformManager& pm, Inventory* inventory) override;
+    virtual void run(PlatformManager& pm) override;
 };
 
 class HardwareExecutionEnvironment : public ExecutionEnvironment
@@ -51,5 +51,5 @@ class HardwareExecutionEnvironment : public ExecutionEnvironment
 
     /* ExecutionEnvironment */
     virtual bool probe() override;
-    virtual void run(PlatformManager& pm, Inventory* inventory) override;
+    virtual void run(PlatformManager& pm) override;
 };

--- a/src/inventory.hpp
+++ b/src/inventory.hpp
@@ -77,6 +77,8 @@ class InventoryManager : public Inventory
 
   private:
     void slotPowerStateChanged(sdbusplus::message::message&, PlatformManager*);
+    void checkSlotPowerStates(PlatformManager*);
+    void checkSlotPowerState(const std::string& slotPath, PlatformManager* pm);
     sdbusplus::bus::bus& dbus;
     std::unique_ptr<sdbusplus::bus::match::match> slotPowerStateChangedMatch;
 };

--- a/src/inventory.hpp
+++ b/src/inventory.hpp
@@ -1,6 +1,10 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 #pragma once
 
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/bus/match.hpp>
+#include <sdbusplus/message.hpp>
+
 #include <map>
 #include <string>
 #include <variant>
@@ -14,6 +18,8 @@ namespace bus
 class bus;
 }
 } // namespace sdbusplus
+
+class PlatformManager;
 
 namespace inventory
 {
@@ -66,9 +72,13 @@ class InventoryManager : public Inventory
     virtual bool isPresent(const std::string& path) override;
     virtual bool isModel(const std::string& path,
                          const std::string& model) override;
+    void watchSlotPowerState(PlatformManager* pm);
+    int getSlotFromPath(const std::string& path);
 
   private:
+    void slotPowerStateChanged(sdbusplus::message::message&, PlatformManager*);
     sdbusplus::bus::bus& dbus;
+    std::unique_ptr<sdbusplus::bus::match::match> slotPowerStateChangedMatch;
 };
 
 /* Unifies the split we have with WilliwakasNVMeDrive and FlettNVMeDrive */

--- a/src/meson.build
+++ b/src/meson.build
@@ -3,6 +3,7 @@ subdir('platforms')
 subdir('devices')
 
 sdbusplus_dep = dependency('sdbusplus', fallback: [ 'sdbusplus', 'sdbusplus_dep' ])
+sdeventplus_dep = dependency('sdeventplus', fallback: [ 'sdeventplus', 'sdeventplus_dep' ])
 phosphor_logging_dep = dependency('phosphor-logging',
 				  fallback: [ 'phosphor-logging', 'phosphor_logging_dep' ])
 
@@ -15,7 +16,7 @@ inventory_dep = declare_dependency(sources: 'inventory.cpp',
 				   include_directories: '.',
 				   dependencies: [ sdbusplus_dep, phosphor_logging_dep ])
 
-fru_deps = [ sysfs_dep, platforms_dep, inventory_dep, devices_dep ]
+fru_deps = [ sysfs_dep, platforms_dep, inventory_dep, devices_dep, sdeventplus_dep ]
 
 platform_fru_detect_sources = [
     'environment.cpp',

--- a/src/notify.hpp
+++ b/src/notify.hpp
@@ -4,6 +4,8 @@
 #include <functional>
 #include <map>
 #include <stdexcept>
+#include <sdeventplus/event.hpp>
+#include <sdeventplus/source/io.hpp>
 
 class NotifySink;
 
@@ -18,8 +20,9 @@ class Notifier
     void run();
 
   private:
-    int epollfd;
-    int exitfd;
+    sdeventplus::Event sdEvent;
+    std::map<int, std::unique_ptr<sdeventplus::source::IO>> sources;
+
 };
 
 class NotifySink

--- a/src/platform-fru-detect.cpp
+++ b/src/platform-fru-detect.cpp
@@ -55,6 +55,8 @@ int main(void)
     SimicsExecutionEnvironment simics;
     em.enrollEnvironment(&simics);
 
+    inventory.watchSlotPowerState(&pm);
+
     em.run(pm);
 
     return 0;

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -29,3 +29,13 @@ void PlatformManager::detectPlatformFrus()
 
     platforms[model]->detectFrus(notifier);
 }
+
+void PlatformManager::slotPowerStateChanged(int slot, bool powerOn)
+{
+    platforms[model]->slotPowerStateChanged(slot, powerOn);
+}
+
+bool PlatformManager::ignoreSlotPowerState(const std::string& slotPath)
+{
+    return platforms[model]->ignoreSlotPowerState(slotPath);
+}

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -23,9 +23,9 @@ bool PlatformManager::isSupportedPlatform() noexcept
     return platforms.contains(model);
 }
 
-void PlatformManager::detectPlatformFrus(Inventory* inventory)
+void PlatformManager::detectPlatformFrus()
 {
     Notifier notifier;
 
-    platforms[model]->detectFrus(notifier, inventory);
+    platforms[model]->detectFrus(notifier);
 }

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -233,6 +233,8 @@ class PlatformManager
     void enrollPlatform(const std::string& model, Platform* platform);
     bool isSupportedPlatform() noexcept;
     void detectPlatformFrus();
+    void slotPowerStateChanged(int slot, bool powerOn);
+    bool ignoreSlotPowerState(const std::string& slotPath);
 
   private:
     std::map<std::string, Platform*> platforms;
@@ -248,6 +250,8 @@ class Platform
 
     virtual void enrollWith(PlatformManager& pm) = 0;
     virtual void detectFrus(Notifier& notifier) = 0;
+    virtual void slotPowerStateChanged(int slot, bool powerOn) = 0;
+    virtual bool ignoreSlotPowerState(const std::string& slotPath) const = 0;
     static inline bool
         isSupportedModel(const std::vector<std::string>& supportedModels,
                          const std::string& actualModel)

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -232,7 +232,7 @@ class PlatformManager
     const std::string& getPlatformModel() noexcept;
     void enrollPlatform(const std::string& model, Platform* platform);
     bool isSupportedPlatform() noexcept;
-    void detectPlatformFrus(Inventory*);
+    void detectPlatformFrus();
 
   private:
     std::map<std::string, Platform*> platforms;
@@ -242,9 +242,20 @@ class PlatformManager
 class Platform
 {
   public:
-    Platform() = default;
+    Platform(Inventory* inventory) : inventory(inventory)
+    {}
     virtual ~Platform() = default;
 
     virtual void enrollWith(PlatformManager& pm) = 0;
-    virtual void detectFrus(Notifier& notifier, Inventory* inventory) = 0;
+    virtual void detectFrus(Notifier& notifier) = 0;
+    static inline bool
+        isSupportedModel(const std::vector<std::string>& supportedModels,
+                         const std::string& actualModel)
+    {
+        return std::find(supportedModels.begin(), supportedModels.end(),
+                         actualModel) != supportedModels.end();
+    }
+
+  protected:
+    Inventory* inventory;
 };

--- a/src/platforms/rainier.hpp
+++ b/src/platforms/rainier.hpp
@@ -178,6 +178,8 @@ class Nisqually : public Device, FRU
     Nisqually& operator=(const Nisqually&& other) = delete;
 
     virtual SysfsI2CBus getFlettSlotI2CBus(int slot) const = 0;
+    virtual SysfsI2CBus getCableCardI2CBus(int slot) const = 0;
+    void slotPowerStateChanged(int slot, bool powerOn);
 
     /* Device */
     virtual void plug(Notifier& notifier) override;
@@ -191,6 +193,8 @@ class Nisqually : public Device, FRU
 
   protected:
     virtual bool isFlettPresentAt(int slot) = 0;
+    bool isCableCardPresentAt(int slot) const;
+    void handlePcieCardTMP435s(int slot, bool powerOn);
 
     Inventory* inventory;
 
@@ -225,6 +229,7 @@ class Nisqually0z : public Nisqually
 
     /* Nisqually */
     virtual SysfsI2CBus getFlettSlotI2CBus(int slot) const override;
+    virtual SysfsI2CBus getCableCardI2CBus(int slot) const override;
 
   protected:
     /* Nisqually */
@@ -244,6 +249,7 @@ class Nisqually1z : public Nisqually
 
     /* Nisqually */
     virtual SysfsI2CBus getFlettSlotI2CBus(int slot) const override;
+    virtual SysfsI2CBus getCableCardI2CBus(int slot) const override;
 
   protected:
     /* Nisqually */
@@ -316,6 +322,8 @@ class Rainier0z : public Platform
     virtual void enrollWith(PlatformManager& pm) override;
     virtual void detectFrus(Notifier& notifier) override;
     static bool isPresent(const std::string& model);
+    void slotPowerStateChanged(int slot, bool powerOn) override;
+    bool ignoreSlotPowerState(const std::string& slotPath) const override;
 
   private:
     Nisqually0z nisqually;
@@ -335,6 +343,8 @@ class Rainier1z : public Platform
     virtual void enrollWith(PlatformManager& pm) override;
     virtual void detectFrus(Notifier& notifier) override;
     static bool isPresent(const std::string& model);
+    void slotPowerStateChanged(int slot, bool powerOn) override;
+    bool ignoreSlotPowerState(const std::string& slotPath) const override;
 
   private:
     Nisqually1z nisqually;

--- a/src/platforms/rainier.hpp
+++ b/src/platforms/rainier.hpp
@@ -17,6 +17,7 @@
 
 class Flett;
 class Inventory;
+class InventoryManager;
 class Nisqually;
 class Williwakas;
 
@@ -306,19 +307,37 @@ class Ingraham : public Device
 class Rainier0z : public Platform
 {
   public:
-    Rainier0z() = default;
+    Rainier0z(Inventory* inventory) :
+        Platform(inventory), nisqually(inventory),
+        ingraham(inventory, &nisqually)
+    {}
     virtual ~Rainier0z() = default;
 
     virtual void enrollWith(PlatformManager& pm) override;
-    virtual void detectFrus(Notifier& notifier, Inventory* inventory) override;
+    virtual void detectFrus(Notifier& notifier) override;
+    static bool isPresent(const std::string& model);
+
+  private:
+    Nisqually0z nisqually;
+    Ingraham ingraham;
+    static const std::vector<std::string> modelNames;
 };
 
 class Rainier1z : public Platform
 {
   public:
-    Rainier1z() = default;
+    Rainier1z(Inventory* inventory) :
+        Platform(inventory), nisqually(inventory),
+        ingraham(inventory, &nisqually)
+    {}
     virtual ~Rainier1z() = default;
 
     virtual void enrollWith(PlatformManager& pm) override;
-    virtual void detectFrus(Notifier& notifier, Inventory* inventory) override;
+    virtual void detectFrus(Notifier& notifier) override;
+    static bool isPresent(const std::string& model);
+
+  private:
+    Nisqually1z nisqually;
+    Ingraham ingraham;
+    static const std::vector<std::string> modelNames;
 };

--- a/src/platforms/rainier/nisqually.cpp
+++ b/src/platforms/rainier/nisqually.cpp
@@ -222,6 +222,11 @@ SysfsI2CBus Nisqually0z::getFlettSlotI2CBus(int slot) const
 
 bool Nisqually0z::isFlettPresentAt(int slot)
 {
+    if (!flett_slot_presence_map.contains(slot))
+    {
+        return false;
+    }
+
     std::string path = Flett::getInventoryPathFor(this, slot);
 
     bool populated = inventory->isPresent(path);
@@ -297,11 +302,19 @@ SysfsI2CBus Nisqually1z::getFlettSlotI2CBus(int slot) const
  */
 bool Nisqually1z::isFlettPresentAt(int slot)
 {
-    bool present = flettPresenceLines.at(slot).get_value();
+    bool present = false;
+    if (flettPresenceLines.contains(slot))
+    {
+        present = flettPresenceLines.at(slot).get_value();
 
-    debug("Flett {FLETT_ID} presence for slot {PCIE_SLOT}: {FLETT_PRESENT}",
-          "FLETT_ID", getFlettIndex(slot), "PCIE_SLOT", slot, "FLETT_PRESENT",
-          present);
+        debug("Flett {FLETT_ID} presence for slot {PCIE_SLOT}: {FLETT_PRESENT}",
+              "FLETT_ID", getFlettIndex(slot), "PCIE_SLOT", slot,
+              "FLETT_PRESENT", present);
+    }
+    else
+    {
+        debug("Slot {SLOT} is not a Flett slot", "SLOT", slot);
+    }
 
     return present;
 }

--- a/src/platforms/rainier/rainier.cpp
+++ b/src/platforms/rainier/rainier.cpp
@@ -2,18 +2,30 @@
 
 #include "platforms/rainier.hpp"
 
-void Rainier0z::enrollWith(PlatformManager& pm)
+#include <sdbusplus/bus.hpp>
+
+PHOSPHOR_LOG2_USING;
+
+const std::vector<std::string> Rainier0z::modelNames{
+    "Rainier 1S4U Pass 1", "Rainier 4U Pass 1", "Rainier 2U Pass 1"};
+
+const std::vector<std::string> Rainier1z::modelNames{
+    "Rainier 1S4U", "Rainier 4U", "Rainier 2U"};
+
+bool Rainier0z::isPresent(const std::string& model)
 {
-    pm.enrollPlatform("Rainier 1S4U Pass 1", this);
-    pm.enrollPlatform("Rainier 4U Pass 1", this);
-    pm.enrollPlatform("Rainier 2U Pass 1", this);
+    return Platform::isSupportedModel(modelNames, model);
 }
 
-void Rainier0z::detectFrus(Notifier& notifier, Inventory* inventory)
+void Rainier0z::enrollWith(PlatformManager& pm)
 {
-    Nisqually0z nisqually(inventory);
-    Ingraham ingraham(inventory, &nisqually);
+    std::for_each(
+        modelNames.begin(), modelNames.end(),
+        [&pm, this](const auto& name) { pm.enrollPlatform(name, this); });
+}
 
+void Rainier0z::detectFrus(Notifier& notifier)
+{
     /* Cold-plug devices */
     ingraham.plug(notifier);
 
@@ -24,18 +36,20 @@ void Rainier0z::detectFrus(Notifier& notifier, Inventory* inventory)
     ingraham.unplug(notifier, ingraham.UNPLUG_RETAINS_INVENTORY);
 }
 
-void Rainier1z::enrollWith(PlatformManager& pm)
+bool Rainier1z::isPresent(const std::string& model)
 {
-    pm.enrollPlatform("Rainier 1S4U", this);
-    pm.enrollPlatform("Rainier 4U", this);
-    pm.enrollPlatform("Rainier 2U", this);
+    return Platform::isSupportedModel(modelNames, model);
 }
 
-void Rainier1z::detectFrus(Notifier& notifier, Inventory* inventory)
+void Rainier1z::enrollWith(PlatformManager& pm)
 {
-    Nisqually1z nisqually(inventory);
-    Ingraham ingraham(inventory, &nisqually);
+    std::for_each(
+        modelNames.begin(), modelNames.end(),
+        [&pm, this](const auto& name) { pm.enrollPlatform(name, this); });
+}
 
+void Rainier1z::detectFrus(Notifier& notifier)
+{
     /* Cold-plug devices */
     ingraham.plug(notifier);
 

--- a/src/platforms/rainier/rainier.cpp
+++ b/src/platforms/rainier/rainier.cpp
@@ -12,6 +12,9 @@ const std::vector<std::string> Rainier0z::modelNames{
 const std::vector<std::string> Rainier1z::modelNames{
     "Rainier 1S4U", "Rainier 4U", "Rainier 2U"};
 
+static constexpr auto rainierPCIeCardInventoryRoot =
+    "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot";
+
 bool Rainier0z::isPresent(const std::string& model)
 {
     return Platform::isSupportedModel(modelNames, model);
@@ -36,6 +39,16 @@ void Rainier0z::detectFrus(Notifier& notifier)
     ingraham.unplug(notifier, ingraham.UNPLUG_RETAINS_INVENTORY);
 }
 
+void Rainier0z::slotPowerStateChanged(int slot, bool powerOn)
+{
+    nisqually.slotPowerStateChanged(slot, powerOn);
+}
+
+bool Rainier0z::ignoreSlotPowerState(const std::string& slotPath) const
+{
+    return !slotPath.starts_with(rainierPCIeCardInventoryRoot);
+}
+
 bool Rainier1z::isPresent(const std::string& model)
 {
     return Platform::isSupportedModel(modelNames, model);
@@ -58,4 +71,14 @@ void Rainier1z::detectFrus(Notifier& notifier)
 
     /* Clean up the application state but leave the inventory in-tact. */
     ingraham.unplug(notifier, ingraham.UNPLUG_RETAINS_INVENTORY);
+}
+
+void Rainier1z::slotPowerStateChanged(int slot, bool powerOn)
+{
+    nisqually.slotPowerStateChanged(slot, powerOn);
+}
+
+bool Rainier1z::ignoreSlotPowerState(const std::string& slotPath) const
+{
+    return !slotPath.starts_with(rainierPCIeCardInventoryRoot);
 }


### PR DESCRIPTION
The only way to know when the TMP435s on the Flett and Bear Lake/River cards power on is when the PowerState property on the PCIE slot D-Bus objects in the inventory change to on.  Watch those and enable the drivers at that time.  When the state changes to off, disable the drivers.

Also read the slot power states on startup and if any slots are on, enable the drivers then as well.  That handles the reboot at runtime case.

This required a bit of other refactoring to the code so the Rainier and Nisqually objects would be available on the propertiesChanged callbacks.