### PR TITLE
Fix drive serial parsing

### DIFF
--- a/src/devices/meson.build
+++ b/src/devices/meson.build
@@ -1,1 +1,1 @@
-devices_dep = declare_dependency(sources: 'nvme.cpp', include_directories: '.')
+devices_dep = declare_dependency(sources: 'nvme.cpp')

--- a/src/devices/nvme.cpp
+++ b/src/devices/nvme.cpp
@@ -69,7 +69,7 @@ std::vector<uint8_t>
 {
     std::vector<uint8_t> manufacturer;
     if (metadata.size() >= 2) {
-        manufacturer.insert(metadata.begin(), metadata.begin(),
+        manufacturer.insert(manufacturer.begin(), metadata.begin(),
                             metadata.begin() + 2);
     } else {
         warning("Invalid metadata length: {METADATA_LENGTH}", "METADATA_LENGTH", metadata.size());
@@ -82,7 +82,7 @@ std::vector<uint8_t>
 {
     std::vector<uint8_t> serial;
     if (metadata.size() >= 2) {
-        serial.insert(metadata.begin(), metadata.begin() + 2, metadata.end());
+        serial.insert(serial.begin(), metadata.begin() + 2, metadata.end());
     } else {
         warning("No drive serial data present. Invalid metadata of length: {METADATA_LENGTH}",
                 "METADATA_LENGTH", metadata.size());

--- a/src/devices/nvme.cpp
+++ b/src/devices/nvme.cpp
@@ -68,8 +68,12 @@ std::vector<uint8_t>
     BasicNVMeDrive::extractManufacturer(const std::vector<uint8_t>& metadata)
 {
     std::vector<uint8_t> manufacturer;
-    manufacturer.insert(metadata.begin(), metadata.begin(),
-                        metadata.begin() + 2);
+    if (metadata.size() >= 2) {
+        manufacturer.insert(metadata.begin(), metadata.begin(),
+                            metadata.begin() + 2);
+    } else {
+        warning("Invalid metadata length: {METADATA_LENGTH}", "METADATA_LENGTH", metadata.size());
+    }
     return manufacturer;
 }
 
@@ -77,7 +81,12 @@ std::vector<uint8_t>
     BasicNVMeDrive::extractSerial(const std::vector<uint8_t>& metadata)
 {
     std::vector<uint8_t> serial;
-    serial.insert(metadata.begin(), metadata.begin() + 2, metadata.end());
+    if (metadata.size() >= 2) {
+        serial.insert(metadata.begin(), metadata.begin() + 2, metadata.end());
+    } else {
+        warning("No drive serial data present. Invalid metadata of length: {METADATA_LENGTH}",
+                "METADATA_LENGTH", metadata.size());
+    }
     return serial;
 }
 

--- a/src/devices/nvme.hpp
+++ b/src/devices/nvme.hpp
@@ -52,6 +52,8 @@ class BasicNVMeDrive : public NVMeDrive
     static bool isDriveReady(const SysfsI2CBus& bus);
 
     BasicNVMeDrive(const SysfsI2CBus& bus, Inventory* inventory, int index);
+    BasicNVMeDrive(const SysfsI2CBus& bus, Inventory* inventory, int index,
+                   const std::vector<uint8_t>&& metadata);
     virtual ~BasicNVMeDrive() = default;
 
     /* FRU */
@@ -68,9 +70,6 @@ class BasicNVMeDrive : public NVMeDrive
         extractManufacturer(const std::vector<uint8_t>& metadata);
     static std::vector<uint8_t>
         extractSerial(const std::vector<uint8_t>& metadata);
-
-    BasicNVMeDrive(const SysfsI2CBus& bus, Inventory* inventory, int index,
-                   const std::vector<uint8_t>&& metadata);
 
     static constexpr int endpointAddress = 0x6a;
     static constexpr int vendorMetadataOffset = 0x08;

--- a/src/meson.build
+++ b/src/meson.build
@@ -11,14 +11,16 @@ phosphor_logging_dep = dependency('phosphor-logging',
 cpp = meson.get_compiler('cpp')
 i2c_dep = cpp.find_library('i2c')
 
+headers_dep = declare_dependency(include_directories: [ '.' ])
+
 # Used by inventory tests
 inventory_test_dep = declare_dependency(sources: [ 'dbus.cpp' ],
-				   include_directories: '.',
-				   dependencies: [ inventory_dep,
+				   dependencies: [ headers_dep,
+						   inventory_dep,
 						   sdbusplus_dep,
 						   phosphor_logging_dep ])
 
-fru_deps = [ sysfs_dep, platforms_dep, inventory_dep, devices_dep ]
+fru_deps = [ headers_dep, sysfs_dep, platforms_dep, inventory_dep, devices_dep ]
 
 platform_fru_detect_sources = [
     'dbus.cpp',

--- a/src/sysfs/i2c.hpp
+++ b/src/sysfs/i2c.hpp
@@ -34,7 +34,8 @@ class SysfsI2CDeviceDriverBindException : public std::exception
 class SysfsI2CBus : public SysfsEntry
 {
   public:
-    SysfsI2CBus(std::filesystem::path path) : SysfsEntry(path)
+    SysfsI2CBus(std::filesystem::path path, bool check = true) :
+        SysfsEntry(path, check)
     {}
     SysfsI2CBus(SysfsI2CMux mux, int channel);
 

--- a/src/sysfs/sysfs.hpp
+++ b/src/sysfs/sysfs.hpp
@@ -10,10 +10,10 @@
 class SysfsEntry
 {
   public:
-    SysfsEntry(std::filesystem::path path) : path(path)
+    SysfsEntry(std::filesystem::path path, bool check = true) : path(path)
     {
 
-        if (!std::filesystem::exists(path))
+        if (check && !std::filesystem::exists(path))
         {
             lg2::error("sysfs path '{SYSFS_PATH}' does not exist", "SYSFS_PATH",
                        path.string());

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -12,3 +12,11 @@ endif
 test('test-inventory',
      executable('test-inventory', 'test-inventory.cpp',
 		dependencies: [ inventory_dep, inventory_test_dep, gtest_dep ]))
+test('test-nvme',
+     executable('test-nvme', 'test-nvme.cpp',
+	        dependencies: [ headers_dep,
+			        devices_dep,
+				sysfs_dep,
+				libgpiodcxx_dep,
+				phosphor_logging_dep,
+				gtest_dep ]))

--- a/src/tests/test-nvme.cpp
+++ b/src/tests/test-nvme.cpp
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright IBM Corp. 2022 */
+#include "devices/nvme.hpp"
+#include "sysfs/i2c.hpp"
+
+#include "gtest/gtest.h"
+
+class TestNVMeDrive : public BasicNVMeDrive
+{
+  public:
+    TestNVMeDrive(const SysfsI2CBus& bus, Inventory* inventory, int index,
+                  const std::vector<uint8_t>&& metadata) :
+        BasicNVMeDrive(bus, inventory, index, std::move(metadata))
+    {}
+
+    /* Device */
+    virtual void plug([[maybe_unused]] Notifier& notifier)
+    {}
+    virtual void unplug([[maybe_unused]] Notifier& notifier,
+                        [[maybe_unused]] int mode = UNPLUG_REMOVES_INVENTORY)
+    {}
+};
+
+TEST(DriveMetadata, smallMetadata)
+{
+    SysfsI2CBus bus("/sys/bus/i2c/devices/i2c-0", false);
+    auto drive = TestNVMeDrive(bus, nullptr, 0, std::vector<uint8_t>{0, 1, 0x44});
+}


### PR DESCRIPTION
Hardware CI discovered some misuse of the `std::vector::insert()` API where the first parameter was an iterator of a different object.