### PR TITLE
Everest: skip ready test

### DIFF
--- a/src/descriptor.cpp
+++ b/src/descriptor.cpp
@@ -8,7 +8,7 @@
 #include <stdexcept>
 
 FileDescriptor::FileDescriptor(const std::filesystem::path& name,
-                       std::ios_base::openmode mode) :
+                               std::ios_base::openmode mode) :
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
     fd(open(name.c_str(), mode))
 {

--- a/src/descriptor.hpp
+++ b/src/descriptor.hpp
@@ -18,8 +18,8 @@ class FileDescriptor
     FileDescriptor& operator=(FileDescriptor&&) noexcept;
 
     explicit FileDescriptor(const std::filesystem::path& name,
-                        std::ios_base::openmode mode = std::ios_base::in |
-                                                       std::ios_base::out);
+                            std::ios_base::openmode mode = std::ios_base::in |
+                                                           std::ios_base::out);
 
     explicit FileDescriptor(int fd);
 

--- a/src/devices/nvme.cpp
+++ b/src/devices/nvme.cpp
@@ -22,33 +22,6 @@ bool BasicNVMeDrive::isBasicEndpointPresent(const SysfsI2CBus& bus)
     return i2c::isDeviceResponsive(bus, BasicNVMeDrive::endpointAddress);
 }
 
-bool BasicNVMeDrive::isDriveReady(const SysfsI2CBus& bus)
-{
-    try
-    {
-        std::vector<uint8_t> status;
-
-        i2c::oneshotSMBusBlockRead(bus, BasicNVMeDrive::endpointAddress, 0,
-                                   status);
-
-        if (status.empty())
-        {
-            return false;
-        }
-
-        return !(status[0] & NVME_BASIC_SFLGS_NOT_READY);
-    }
-    catch (const std::error_condition& ex)
-    {
-        if (ex.value() != ENODEV)
-        {
-            throw ex;
-        }
-    }
-
-    return false;
-}
-
 std::vector<uint8_t> BasicNVMeDrive::fetchMetadata(const SysfsI2CBus& bus)
 {
     std::vector<uint8_t> data;

--- a/src/devices/nvme.cpp
+++ b/src/devices/nvme.cpp
@@ -68,11 +68,15 @@ std::vector<uint8_t>
     BasicNVMeDrive::extractManufacturer(const std::vector<uint8_t>& metadata)
 {
     std::vector<uint8_t> manufacturer;
-    if (metadata.size() >= 2) {
+    if (metadata.size() >= 2)
+    {
         manufacturer.insert(manufacturer.begin(), metadata.begin(),
                             metadata.begin() + 2);
-    } else {
-        warning("Invalid metadata length: {METADATA_LENGTH}", "METADATA_LENGTH", metadata.size());
+    }
+    else
+    {
+        warning("Invalid metadata length: {METADATA_LENGTH}", "METADATA_LENGTH",
+                metadata.size());
     }
     return manufacturer;
 }
@@ -81,11 +85,15 @@ std::vector<uint8_t>
     BasicNVMeDrive::extractSerial(const std::vector<uint8_t>& metadata)
 {
     std::vector<uint8_t> serial;
-    if (metadata.size() >= 2) {
+    if (metadata.size() >= 2)
+    {
         serial.insert(serial.begin(), metadata.begin() + 2, metadata.end());
-    } else {
-        warning("No drive serial data present. Invalid metadata of length: {METADATA_LENGTH}",
-                "METADATA_LENGTH", metadata.size());
+    }
+    else
+    {
+        warning(
+            "No drive serial data present. Invalid metadata of length: {METADATA_LENGTH}",
+            "METADATA_LENGTH", metadata.size());
     }
     return serial;
 }

--- a/src/devices/nvme.hpp
+++ b/src/devices/nvme.hpp
@@ -48,7 +48,6 @@ class BasicNVMeDrive : public NVMeDrive
 {
   public:
     static bool isBasicEndpointPresent(const SysfsI2CBus& bus);
-    static bool isDriveReady(const SysfsI2CBus& bus);
 
     BasicNVMeDrive(const SysfsI2CBus& bus, Inventory* inventory, int index);
     BasicNVMeDrive(const SysfsI2CBus& bus, Inventory* inventory, int index,

--- a/src/environment.hpp
+++ b/src/environment.hpp
@@ -43,7 +43,8 @@ class SimicsExecutionEnvironment : public ExecutionEnvironment
 
     /* ExecutionEnvironment */
     bool probe() override;
-    void run(PlatformManager& pm, Notifier& notifier, Inventory* inventory) override;
+    void run(PlatformManager& pm, Notifier& notifier,
+             Inventory* inventory) override;
 };
 
 class HardwareExecutionEnvironment : public ExecutionEnvironment
@@ -54,5 +55,6 @@ class HardwareExecutionEnvironment : public ExecutionEnvironment
 
     /* ExecutionEnvironment */
     bool probe() override;
-    void run(PlatformManager& pm, Notifier& notifier, Inventory* inventory) override;
+    void run(PlatformManager& pm, Notifier& notifier,
+             Inventory* inventory) override;
 };

--- a/src/i2c.cpp
+++ b/src/i2c.cpp
@@ -1,7 +1,8 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* Copyright IBM Corp. 2021 */
-#include "descriptor.hpp"
 #include "i2c.hpp"
+
+#include "descriptor.hpp"
 
 #include <phosphor-logging/lg2.hpp>
 

--- a/src/inventory.hpp
+++ b/src/inventory.hpp
@@ -147,15 +147,15 @@ class InventoryManager : public Inventory
     ~InventoryManager() override = default;
 
     /* Inventory */
-    std::weak_ptr<dbus::PropertiesChangedListener>
-        addPropertiesChangedListener(
-            const std::string& path, const std::string& interface,
-            std::function<void(dbus::PropertiesChanged&& props)> callback)
-            override;
+    std::weak_ptr<dbus::PropertiesChangedListener> addPropertiesChangedListener(
+        const std::string& path, const std::string& interface,
+        std::function<void(dbus::PropertiesChanged&& props)> callback) override;
     void removePropertiesChangedListener(
         std::weak_ptr<dbus::PropertiesChangedListener> listener) override;
-    void add(const std::string& path, const inventory::interfaces::Interface iface) override;
-    void remove(const std::string& path, const inventory::interfaces::Interface iface) override;
+    void add(const std::string& path,
+             const inventory::interfaces::Interface iface) override;
+    void remove(const std::string& path,
+                const inventory::interfaces::Interface iface) override;
     void markPresent(const std::string& path) override;
     void markAbsent(const std::string& path) override;
     bool isPresent(const std::string& path) override;
@@ -177,15 +177,15 @@ class PublishWhenPresentInventoryDecorator : public Inventory
     ~PublishWhenPresentInventoryDecorator() override = default;
 
     /* Inventory */
-    std::weak_ptr<dbus::PropertiesChangedListener>
-        addPropertiesChangedListener(
-            const std::string& path, const std::string& interface,
-            std::function<void(dbus::PropertiesChanged&& props)> callback)
-            override;
+    std::weak_ptr<dbus::PropertiesChangedListener> addPropertiesChangedListener(
+        const std::string& path, const std::string& interface,
+        std::function<void(dbus::PropertiesChanged&& props)> callback) override;
     void removePropertiesChangedListener(
         std::weak_ptr<dbus::PropertiesChangedListener> listener) override;
-    void add(const std::string& path, const inventory::interfaces::Interface iface) override;
-    void remove(const std::string& path, const inventory::interfaces::Interface iface) override;
+    void add(const std::string& path,
+             const inventory::interfaces::Interface iface) override;
+    void remove(const std::string& path,
+                const inventory::interfaces::Interface iface) override;
     void markPresent(const std::string& path) override;
     void markAbsent(const std::string& path) override;
     bool isPresent(const std::string& path) override;

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -102,8 +102,10 @@ class PolledDevicePresence : public NotifySink
 {
   public:
     PolledDevicePresence() = default;
-    PolledDevicePresence(Connector<T>* connector, const std::function<bool()>& poll) :
-        connector(connector), poll(poll), timerfd(-1)
+    PolledDevicePresence(Connector<T>* connector,
+                         const std::function<bool()>& poll) :
+        connector(connector),
+        poll(poll), timerfd(-1)
     {}
     ~PolledDevicePresence() override = default;
 

--- a/src/platforms/everest.hpp
+++ b/src/platforms/everest.hpp
@@ -18,7 +18,8 @@ class BasecampNVMeDrive : public BasicNVMeDrive
 
     /* Device */
     void plug(Notifier& notifier) override;
-    void unplug(Notifier& notifier, int mode = UNPLUG_REMOVES_INVENTORY) override;
+    void unplug(Notifier& notifier,
+                int mode = UNPLUG_REMOVES_INVENTORY) override;
 
     /* FRU */
     std::string getInventoryPath() const override;
@@ -44,7 +45,8 @@ class Basecamp : public Device, FRU
 
     /* Device */
     void plug(Notifier& notifier) override;
-    void unplug(Notifier& notifier, int mode = Device::UNPLUG_REMOVES_INVENTORY) override;
+    void unplug(Notifier& notifier,
+                int mode = Device::UNPLUG_REMOVES_INVENTORY) override;
 
     /* FRU */
     std::string getInventoryPath() const override;
@@ -58,14 +60,14 @@ class Basecamp : public Device, FRU
     static constexpr int driveMetadataMuxChannel = 3;
     static constexpr int drivePresenceDeviceAddress = 0x61;
     static constexpr std::array<int, 10> drivePresenceMap = {0, 1, 2, 3, 4,
-                                                               5, 6, 7, 8, 9};
+                                                             5, 6, 7, 8, 9};
 
     static constexpr const char* driveManagementBus =
         "/sys/bus/i2c/devices/i2c-15";
     static constexpr std::array<int, 10> driveMuxMap = {
         0x70, 0x70, 0x70, 0x70, 0x71, 0x71, 0x71, 0x71, 0x72, 0x72};
     static constexpr std::array<int, 10> driveChannelMap = {0, 1, 2, 3, 0,
-                                                              1, 2, 3, 0, 1};
+                                                            1, 2, 3, 0, 1};
 
     Inventory* inventory;
     const Bellavista* bellavista;
@@ -87,7 +89,8 @@ class Bellavista : public Device, FRU
 
     /* Device */
     void plug(Notifier& notifier) override;
-    void unplug(Notifier& notifier, int mode = Device::UNPLUG_REMOVES_INVENTORY) override;
+    void unplug(Notifier& notifier,
+                int mode = Device::UNPLUG_REMOVES_INVENTORY) override;
 
     /* FRU */
     std::string getInventoryPath() const override;
@@ -119,7 +122,8 @@ class Tola : public Device
 
     /* Device */
     void plug(Notifier& notifier) override;
-    void unplug(Notifier& notifier, int mode = Device::UNPLUG_REMOVES_INVENTORY) override;
+    void unplug(Notifier& notifier,
+                int mode = Device::UNPLUG_REMOVES_INVENTORY) override;
 
   private:
     Inventory* inventory;

--- a/src/platforms/everest/basecamp.cpp
+++ b/src/platforms/everest/basecamp.cpp
@@ -65,8 +65,7 @@ Basecamp::Basecamp(Inventory* inventory, const Bellavista* bellavista) :
     SysfsI2CMux mux(root, driveMetadataMuxAddress);
     SysfsI2CBus bus(mux, driveMetadataMuxChannel);
 
-    SysfsI2CDevice dev =
-        bus.probeDevice("pca9552", drivePresenceDeviceAddress);
+    SysfsI2CDevice dev = bus.probeDevice("pca9552", drivePresenceDeviceAddress);
 
     std::string chipName = SysfsGPIOChip(dev).getName().string();
     gpiod::chip chip(chipName, gpiod::chip::OPEN_BY_NAME);

--- a/src/platforms/everest/basecamp.cpp
+++ b/src/platforms/everest/basecamp.cpp
@@ -99,7 +99,8 @@ void Basecamp::plug(Notifier& notifier)
         SysfsI2CBus bus = getDriveBus(i);
         presenceAdaptors[i] = PolledDevicePresence<BasecampNVMeDrive>(
             &driveConnectors.at(i), [line, bus]() {
-                return line->get_value() && BasicNVMeDrive::isDriveReady(bus);
+                return line->get_value() &&
+                       BasicNVMeDrive::isBasicEndpointPresent(bus);
             });
         notifier.add(&presenceAdaptors.at(i));
     }

--- a/src/platforms/everest/basecamp.cpp
+++ b/src/platforms/everest/basecamp.cpp
@@ -88,7 +88,7 @@ SysfsI2CBus Basecamp::getDriveBus(int index) const
     SysfsI2CBus root(driveManagementBus);
     SysfsI2CMux driveMux(root, driveMuxMap.at(index));
 
-    return SysfsI2CBus(driveMux, driveChannelMap.at(index));
+    return {driveMux, driveChannelMap.at(index)};
 }
 
 void Basecamp::plug(Notifier& notifier)

--- a/src/platforms/rainier.hpp
+++ b/src/platforms/rainier.hpp
@@ -38,7 +38,8 @@ class FlettNVMeDrive : public BasicNVMeDrive
 
     /* Device */
     void plug(Notifier& notifier) override;
-    void unplug(Notifier& notifier, int mode = UNPLUG_REMOVES_INVENTORY) override;
+    void unplug(Notifier& notifier,
+                int mode = UNPLUG_REMOVES_INVENTORY) override;
 
     /* FRU */
     std::string getInventoryPath() const override;
@@ -71,7 +72,8 @@ class Flett : public Device
 
     /* Device */
     void plug(Notifier& notifier) override;
-    void unplug(Notifier& notifier, int mode = Device::UNPLUG_REMOVES_INVENTORY) override;
+    void unplug(Notifier& notifier,
+                int mode = Device::UNPLUG_REMOVES_INVENTORY) override;
 
   private:
     Inventory* inventory;
@@ -95,7 +97,8 @@ class WilliwakasNVMeDrive : public NVMeDrive
 
     /* Device */
     void plug(Notifier& notifier) override;
-    void unplug(Notifier& notifier, int mode = UNPLUG_REMOVES_INVENTORY) override;
+    void unplug(Notifier& notifier,
+                int mode = UNPLUG_REMOVES_INVENTORY) override;
 
     /* FRU */
     std::string getInventoryPath() const override;
@@ -125,7 +128,8 @@ class Williwakas : public Device, FRU
 
     /* Device */
     void plug(Notifier& notifier) override;
-    void unplug(Notifier& notifier, int mode = Device::UNPLUG_REMOVES_INVENTORY) override;
+    void unplug(Notifier& notifier,
+                int mode = Device::UNPLUG_REMOVES_INVENTORY) override;
 
     /* FRU */
     std::string getInventoryPath() const override;
@@ -176,7 +180,8 @@ class Nisqually : public Device, FRU
 
     /* Device */
     void plug(Notifier& notifier) override;
-    void unplug(Notifier& notifier, int mode = Device::UNPLUG_REMOVES_INVENTORY) override;
+    void unplug(Notifier& notifier,
+                int mode = Device::UNPLUG_REMOVES_INVENTORY) override;
 
     /* FRU */
     std::string getInventoryPath() const override;
@@ -254,7 +259,8 @@ class Ingraham : public Device
 
     /* Device */
     void plug(Notifier& notifier) override;
-    void unplug(Notifier& notifier, int mode = Device::UNPLUG_REMOVES_INVENTORY) override;
+    void unplug(Notifier& notifier,
+                int mode = Device::UNPLUG_REMOVES_INVENTORY) override;
 
   private:
     static constexpr std::array<const char*, 12> pcieSlotBusMap = {

--- a/src/platforms/rainier/ingraham.cpp
+++ b/src/platforms/rainier/ingraham.cpp
@@ -13,7 +13,7 @@ Ingraham::Ingraham(Inventory* inventory, Nisqually* nisqually) :
 
 SysfsI2CBus Ingraham::getPCIeSlotI2CBus(int slot)
 {
-    return SysfsI2CBus(fs::path(Ingraham::pcieSlotBusMap.at(slot)));
+    return {fs::path(Ingraham::pcieSlotBusMap.at(slot))};
 }
 
 void Ingraham::plug(Notifier& notifier)

--- a/src/platforms/rainier/nisqually.cpp
+++ b/src/platforms/rainier/nisqually.cpp
@@ -71,8 +71,7 @@ Nisqually::Nisqually(Inventory* inventory) :
         Connector<Williwakas>(this->inventory, this, 2),
     }}
 {
-    for (int i :
-         std::views::iota(0UL, Nisqually::williwakasPresenceMap.size()))
+    for (int i : std::views::iota(0UL, Nisqually::williwakasPresenceMap.size()))
     {
         int offset = Nisqually::williwakasPresenceMap.at(i);
         gpiod::line line = williwakasPresenceChip.get_line(offset);

--- a/src/sysfs/eeprom.hpp
+++ b/src/sysfs/eeprom.hpp
@@ -16,7 +16,8 @@ class SysfsEEPROM : public SysfsEntry
     {}
     SysfsEEPROM(const std::filesystem::path& path) : SysfsEntry(path)
     {}
-    SysfsEEPROM(const SysfsI2CDevice& device) : SysfsEntry(device.getPath() / "eeprom")
+    SysfsEEPROM(const SysfsI2CDevice& device) :
+        SysfsEntry(device.getPath() / "eeprom")
     {}
 
     SysfsEEPROM(SysfsEEPROM& other) = default;

--- a/src/sysfs/i2c.hpp
+++ b/src/sysfs/i2c.hpp
@@ -84,7 +84,8 @@ class SysfsI2CMux : public SysfsI2CDevice
     {}
     SysfsI2CMux(const std::filesystem::path& path) : SysfsI2CDevice(path)
     {}
-    SysfsI2CMux(const SysfsI2CBus& bus, int address) : SysfsI2CDevice(bus, address)
+    SysfsI2CMux(const SysfsI2CBus& bus, int address) :
+        SysfsI2CDevice(bus, address)
     {}
 
     ~SysfsI2CMux() override = default;

--- a/src/sysfs/i2c/device.cpp
+++ b/src/sysfs/i2c/device.cpp
@@ -7,7 +7,8 @@
 
 namespace fs = std::filesystem;
 
-std::string SysfsI2CDevice::generateI2CDeviceID(const SysfsI2CBus& bus, int address)
+std::string SysfsI2CDevice::generateI2CDeviceID(const SysfsI2CBus& bus,
+                                                int address)
 {
     std::ostringstream oss;
 

--- a/src/sysfs/sysfs.hpp
+++ b/src/sysfs/sysfs.hpp
@@ -10,7 +10,8 @@
 class SysfsEntry
 {
   public:
-    SysfsEntry(const std::filesystem::path& path, bool check = true) : path(path)
+    SysfsEntry(const std::filesystem::path& path, bool check = true) :
+        path(path)
     {
 
         if (check && !std::filesystem::exists(path))

--- a/src/tests/test-inventory.cpp
+++ b/src/tests/test-inventory.cpp
@@ -47,12 +47,11 @@ static void accumulate(std::map<std::string, ObjectType>& store,
 
 struct MockInventory : public Inventory
 {
-    std::weak_ptr<dbus::PropertiesChangedListener>
-        addPropertiesChangedListener(
-            [[maybe_unused]] const std::string& path,
-            [[maybe_unused]] const std::string& interface,
-            [[maybe_unused]] std::function<void(dbus::PropertiesChanged&&)>
-                callback) override
+    std::weak_ptr<dbus::PropertiesChangedListener> addPropertiesChangedListener(
+        [[maybe_unused]] const std::string& path,
+        [[maybe_unused]] const std::string& interface,
+        [[maybe_unused]] std::function<void(dbus::PropertiesChanged&&)>
+            callback) override
     {
         throw std::logic_error("Unimplemented");
     }
@@ -98,7 +97,7 @@ struct MockInventory : public Inventory
     }
 
     bool isModel([[maybe_unused]] const std::string& path,
-                         [[maybe_unused]] const std::string& model) override
+                 [[maybe_unused]] const std::string& model) override
     {
         throw std::logic_error("Unimplemented");
     }

--- a/src/tests/test-nvme.cpp
+++ b/src/tests/test-nvme.cpp
@@ -25,5 +25,6 @@ class TestNVMeDrive : public BasicNVMeDrive
 TEST(DriveMetadata, smallMetadata)
 {
     SysfsI2CBus bus("/sys/bus/i2c/devices/i2c-0", false);
-    auto drive = TestNVMeDrive(bus, nullptr, 0, std::vector<uint8_t>{0, 1, 0x44});
+    auto drive =
+        TestNVMeDrive(bus, nullptr, 0, std::vector<uint8_t>{0, 1, 0x44});
 }


### PR DESCRIPTION
platform-fru-detect was querying the drive ready state for everest and causing itself some headaches. Stop that, as nvmesensor now handles drive readiness itself and it's not correct to do that in platform-fru-detect. It's enough to know the drive is present and responsive.

As part of the process of fixing how we detect the drives, also minimise traffic to the drive by eliminating I2C endpoint queries after the first success while the presence detect GPIO remains asserted.