### PR TITLE
Update service dependency

### DIFF
--- a/systemd/system/platform-fru-detect.service
+++ b/systemd/system/platform-fru-detect.service
@@ -2,10 +2,12 @@
 Description=Detect undiscoverable platform FRUs
 Wants=xyz.openbmc_project.Inventory.Manager.service
 After=xyz.openbmc_project.Inventory.Manager.service
+Wants=system-vpd.service
+After=system-vpd.service
 
 [Service]
 Type=simple
 ExecStart=/usr/bin/platform-fru-detect
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target


### PR DESCRIPTION
fru-detect.service needs to be dependent on system-vpd.service because during the execution of system-vpd.service somes muxes are enabled and henceforth devices behind those muxes becomes accessible.
Without that the accessibility remains restricted and fru detect will fail for those FRUs.