### PR TITLE
Add dependency for wait-vpd-parser.service

### DIFF
--- a/systemd/system/platform-fru-detect.service
+++ b/systemd/system/platform-fru-detect.service
@@ -4,6 +4,7 @@ Wants=xyz.openbmc_project.Inventory.Manager.service
 After=xyz.openbmc_project.Inventory.Manager.service
 Wants=system-vpd.service
 After=system-vpd.service
+After=wait-vpd-parsers.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
In some corner cases, there has been a race condition between inventory path for some of the FRUs getting populated and Platform-fru-detect trying to populate those FRUs by updating VPD data for those FRUs under the respective inventory paths.

The change adds dependecy to delay the Platform-fru-detect till the time VPD code is done populating all the FRUs thus avoiding the race condition.