### PR TITLE
1030: Add dependency for wait-vpd-parser.service (#22) & Update service dependency (#21)

### DIFF
--- a/systemd/system/platform-fru-detect.service
+++ b/systemd/system/platform-fru-detect.service
@@ -4,6 +4,7 @@ Wants=xyz.openbmc_project.Inventory.Manager.service
 After=xyz.openbmc_project.Inventory.Manager.service
 Wants=system-vpd.service
 After=system-vpd.service
+After=wait-vpd-parsers.service
 
 [Service]
 Type=simple

--- a/systemd/system/platform-fru-detect.service
+++ b/systemd/system/platform-fru-detect.service
@@ -2,10 +2,12 @@
 Description=Detect undiscoverable platform FRUs
 Wants=xyz.openbmc_project.Inventory.Manager.service
 After=xyz.openbmc_project.Inventory.Manager.service
+Wants=system-vpd.service
+After=system-vpd.service
 
 [Service]
 Type=simple
 ExecStart=/usr/bin/platform-fru-detect
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target


### PR DESCRIPTION
#### Add dependency for wait-vpd-parser.service (#22)
```
In some corner cases, there has been a race condition between
inventory path for some of the FRUs getting populated and
Platform-fru-detect trying to populate those FRUs by updating
VPD data for those FRUs under the respective inventory paths.

The change adds dependecy to delay the Platform-fru-detect till the
time VPD code is done populating all the FRUs thus avoiding the
race condition.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>```
```

#### Update service dependency (#21)
```
fru-detect.service needs to be dependent on system-vpd.service
because during the execution of system-vpd.service somes muxes
are enabled and henceforth devices behind those muxes becomes
accessible.
Without that the accessibility remains restricted and fru detect
will fail for those FRUs.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>
```