### PR TITLE
platforms: Add support for BlueRidge and Fuji

### DIFF
--- a/src/platforms/everest/everest.cpp
+++ b/src/platforms/everest/everest.cpp
@@ -7,6 +7,7 @@
 void Everest::enrollWith(PlatformManager& pm)
 {
     pm.enrollPlatform("Everest", this);
+    pm.enrollPlatform("Fuji", this);
 }
 
 void Everest::detectFrus(Notifier& notifier, Inventory* inventory)

--- a/src/platforms/rainier/rainier.cpp
+++ b/src/platforms/rainier/rainier.cpp
@@ -37,6 +37,9 @@ void Rainier1z::enrollWith(PlatformManager& pm)
     pm.enrollPlatform("Rainier 1S4U", this);
     pm.enrollPlatform("Rainier 4U", this);
     pm.enrollPlatform("Rainier 2U", this);
+    pm.enrollPlatform("Blueridge 1S4U", this);
+    pm.enrollPlatform("Blueridge 4U", this);
+    pm.enrollPlatform("Blueridge 2U", this);
 }
 
 void Rainier1z::detectFrus(Notifier& notifier, Inventory* inventory)


### PR DESCRIPTION
BlueRidge uses the same hardware as Rainier and has the same 3 models, and Fuji uses the same hardware as Everest.

These names added were taken from the corresponding device tree files.