### PR TITLE
Create dependency with clear fault led script

### DIFF
--- a/systemd/system/platform-fru-detect.service
+++ b/systemd/system/platform-fru-detect.service
@@ -5,6 +5,7 @@ After=xyz.openbmc_project.Inventory.Manager.service
 Wants=system-vpd.service
 After=system-vpd.service
 After=wait-vpd-parsers.service
+After=obmc-clear-all-fault-leds-and-remove-crit-association@true.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
The dependency has been created to remove race condition between platform fru detect and clear fault led script.
There script was core dumping for Dbus paths created by platform fru detect.